### PR TITLE
Hide tooltip when selecting ddl item

### DIFF
--- a/px-tooltip.html
+++ b/px-tooltip.html
@@ -344,12 +344,14 @@ Custom property | Description
             this.listen(this._target[i], "mouseup", "_setOpenedTrue");
             this.listen(this._target[i], "mouseleave", "_setOpenedFalse");
             this.listen(this._target[i], "mousedown", "_setOpenedFalse");
+            this.listen(this._target[i], 'dropdown-selected', '_setOpenedFalse');
           }
         } else {
           this.listen(this._target, "mouseenter", "_setOpenedTrue");
           this.listen(this._target, "mouseup", "_setOpenedTrue");
           this.listen(this._target, "mouseleave", "_setOpenedFalse");
           this.listen(this._target, "mousedown", "_setOpenedFalse");
+          this.listen(this._target, 'dropdown-selected', '_setOpenedFalse');
         }
       }
     },
@@ -366,12 +368,14 @@ Custom property | Description
             this.unlisten(this._target[i], "mouseup", "_setOpenedTrue");
             this.unlisten(this._target[i], "mouseleave", "_setOpenedFalse");
             this.unlisten(this._target[i], "mousedown", "_setOpenedFalse");
+            this.unlisten(this._target[i], 'dropdown-selected', '_setOpenedFalse');
           }
         } else {
           this.unlisten(this._target, "mouseenter", "_setOpenedTrue");
           this.unlisten(this._target, "mouseup", "_setOpenedTrue");
           this.unlisten(this._target, "mouseleave", "_setOpenedFalse");
           this.unlisten(this._target, "mousedown", "_setOpenedFalse");
+          this.unlisten(this._target, 'dropdown-selected', '_setOpenedFalse');
         }
       }
     },


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:

* ## A reference to a related issue (if applicable):

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.

**Description**: After selecting pae-dwopdow item tooltip doesn't hide which is the reason it gets stuck in screen. Added dropdown-selected.

